### PR TITLE
User configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+
+[*.lua]
+indent_size = 2
+
+[*.scm]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Syntax highlighting and runner for [Hurl](https://hurl.dev) files.
 NOTE: This is an unofficial plugin, visit <https://hurl.dev> for more
 information about the project
 
+
 ## Runner
 
-Provides a :Hurl and :HurlNoColor command that run hurl against the current
+Provides a :Hurl command that runs hurl against the current
 file. Opens the results in a floating window.
 
 The :Hurl command creates an nvim terminal to show colorized output from hurl.
@@ -21,8 +22,8 @@ without color to allow for copying without new lines on line wraps.
 ```
 
 ```lua
-require'hurl'.hurl()
-require'hurl'.hurl_no_color()
+require'hurl'.hurl()                  -- Equivalent to :Hurl
+require'hurl'.hurl({ color = false }) -- Equivalent to :HurlNoColor
 ```
 
 ## Setup
@@ -40,8 +41,19 @@ To use the :Hurl command you must have hurl installed on your path.
 Once you install the plugin it can be setup using the setup function:
 
 ``` lua
-require("hurl").setup()
+require("hurl").setup({
+  color = true -- Default: true
+})
 ```
+
+Default settings table:
+```lua
+{
+  color = true
+}
+```
+
+If you would like to modify any of these settings change the corresponding key in the hurl setup function.
 
 The setup function injects the hurl tree-sitter configuration into
 nvim-treesitter but does not install the parser. To install the parser you must

--- a/lua/hurl/config.lua
+++ b/lua/hurl/config.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+---@class HurlConfig
+---@field color boolean
+M.config = {
+  color = true,
+}
+
+---Combines the config with the given user configuration
+---@param user_config HurlConfig
+function M.update_config(user_config)
+  M.config = vim.tbl_deep_extend("force", M.config, user_config)
+end
+
+
+return M

--- a/lua/hurl/init.lua
+++ b/lua/hurl/init.lua
@@ -1,23 +1,33 @@
+local config = require("hurl.config")
 local tree_sitter_config = require("hurl.tree-sitter-config")
 local h = require("hurl.hurl")
 local M = {}
 
 M.register_treesitter = tree_sitter_config.register_treesitter
 M.hurl = h.hurl
-M.hurl_no_color = h.hurl_no_color
+M.hurl_no_color = function ()
+    h.hurl(vim.tbl_deep_extend("force", config.config, { color = false }))
+end
+M.config = config
 
-function M.setup()
+---@param user_config HurlConfig
+function M.setup(user_config)
+  config.update_config(user_config)
   vim.filetype.add({
-	  extension = {
-	    hurl = "hurl",
-	  },
-	  filename = {
-	    [".hurl"] = "hurl",
-	  }
-	})
+    extension = {
+      hurl = "hurl",
+    },
+    filename = {
+      [".hurl"] = "hurl",
+    },
+  })
   M.register_treesitter()
-  vim.api.nvim_create_user_command("Hurl", h.hurl, {})
-  vim.api.nvim_create_user_command("HurlNoColor", h.hurl_no_color, {})
+  vim.api.nvim_create_user_command("Hurl", function()
+    h.hurl(config.config)
+  end, {})
+  vim.api.nvim_create_user_command("HurlNoColor", function()
+    h.hurl(vim.tbl_deep_extend("force", config.config, { color = false }))
+  end, {})
 end
 
 return M


### PR DESCRIPTION
Hey there! I saw #3 and was interested in that feature (and some others) and have created ~~two~~ three small commits.

The first commit in this PR adds an `editorconfig` file which allows editors to sync indentation, spaces, etc. See the [`editorconfig` site](https://editorconfig.org/) for more details. Neovim has had editorconfig support baked in since [`0.9`](https://github.com/neovim/neovim/pull/21633).

The second commit does a bit of code cleanup and enables user configuration. 
1. Removed the redundant function `hurl_no_color` and moved the no color logic to a flag within `hurl`
2. Use a configuration table to pass settings to the `hurl` function, see the `config.lua` file
3. To avoid breaking the API, I wrap `HurlNoColor` in the user command creation to disable color for that invocation and for the exported `M.hurl_no_color` function in `init.lua`

The third commit updates the Readme to reflect the changes from the second commit.

Let me know if there's anything wrong, on my side it seems all good. If you'd like me to break this into two different PRs, one for the editorconfig, another for the user setup, I can do that as well.

If this PR is undesired, no problem, go ahead and close it out.