### PR TITLE
Set buflisted and window/buffers name

### DIFF
--- a/lua/hurl/hurl.lua
+++ b/lua/hurl/hurl.lua
@@ -5,7 +5,7 @@ function M.hurl(config)
   local gheight = vim.api.nvim_list_uis()[1].height
   local gwidth = vim.api.nvim_list_uis()[1].width
   local file = vim.fn.expand("%")
-  local buf = vim.api.nvim_create_buf(false, true)
+  local buf = vim.api.nvim_create_buf(true, true)
   local width = gwidth - 10
   local height = gheight - 4
   vim.api.nvim_open_win(buf, true, {


### PR DESCRIPTION
This allows the terminal window to be properly split via `<C-w>` invocations.

Currently hitting `<C-w>l` does this with the current buffer options:

https://github.com/pfeiferj/nvim-hurl/assets/58627896/9fe59966-011d-4b51-a853-4366e4cf0230

With the changes from this PR:


https://github.com/pfeiferj/nvim-hurl/assets/58627896/7ac04a88-5a7e-4e4a-aa44-209e1d56f38f

That gives the window better control over it with split functionality.

Note though, that with these new changes the window when closed persists its buffer. I have a more comprehensive change in the works that will address this (mainly by deleting the buffer with an `autocmd` on `WinClose` events).

This PR, in the meantime, permits better window controls.

Let me know if there's any issues, and if this is undesired feel free to just close this out :smile:.