### PR TITLE
fix: close the floating window when window is split (`<C-w>v`)

### DIFF
--- a/lua/hurl/hurl.lua
+++ b/lua/hurl/hurl.lua
@@ -8,7 +8,7 @@ function M.hurl(config)
   local buf = vim.api.nvim_create_buf(false, true)
   local width = gwidth - 10
   local height = gheight - 4
-  vim.api.nvim_open_win(buf, true, {
+  local win_id = vim.api.nvim_open_win(buf, true, {
     relative = "editor",
     width = width,
     height = height,
@@ -18,6 +18,19 @@ function M.hurl(config)
     border = "rounded",
   })
   local term = vim.api.nvim_open_term(buf,{})
+
+  -- This ensures the window created is closed instead of covering the editor when a split is created
+  vim.api.nvim_create_autocmd("WinLeave", {
+    pattern = "*",
+    desc = "Win Leave Autocmd to close Hurl Output window on leave",
+    callback = function(args)
+      if args.buf == buf then
+        vim.api.nvim_win_close(win_id, true)
+      end
+      -- Clean this autocmd up
+      vim.api.nvim_del_autocmd(args.id)
+    end,
+  })
 
   -- Build arguments list
   local hurl_args_t = {}


### PR DESCRIPTION
Prior to this commit and usage of `<C-w>v` on the Hurl output float window would case the output to be split into another window, but leave the floating window behind covering the entire editor. At this point the only way to close the floating window is to either target it specifically with a window move command or to use your mouse to select the window then close it out.

How the float window reacted to a split command prior to this commit:

https://github.com/pfeiferj/nvim-hurl/assets/58627896/0cb63f8d-5a6f-4b78-918e-75ff72f42fdb

How the float window works now when being split:

https://github.com/pfeiferj/nvim-hurl/assets/58627896/5a66f76b-c25c-422d-9362-6c91e04a1953

As a note, previously you could properly split the window by using `<C-w>L`, but if you hit `<C-w>v` then you ran into the undesired behavior of the floating window blocking the editor.

Let me know if there's anything wrong/that I can do. If this PR is undesired then go ahead and close it out. :smile: 