### PR TITLE
Pass hurl args

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ without color to allow for copying without new lines on line wraps.
 ```lua
 require'hurl'.hurl()                  -- Equivalent to :Hurl
 require'hurl'.hurl({ color = false }) -- Equivalent to :HurlNoColor
+require'hurl'.hurl({ hurl_flags = { "--location" }}) -- Equivalent to :Hurl --location
 ```
 
 ## Setup
@@ -42,14 +43,16 @@ Once you install the plugin it can be setup using the setup function:
 
 ``` lua
 require("hurl").setup({
-  color = true -- Default: true
+  color = true    -- Default: true
+  hurl_flags = {} -- Default: {}
 })
 ```
 
 Default settings table:
 ```lua
 {
-  color = true
+  color = true,
+  hurl_flags = {}
 }
 ```
 

--- a/lua/hurl/config.lua
+++ b/lua/hurl/config.lua
@@ -2,8 +2,10 @@ local M = {}
 
 ---@class HurlConfig
 ---@field color boolean
+---@field hurl_flags string[]
 M.config = {
   color = true,
+  hurl_flags = {},
 }
 
 ---Combines the config with the given user configuration

--- a/lua/hurl/hurl.lua
+++ b/lua/hurl/hurl.lua
@@ -1,5 +1,18 @@
 local M = {}
 
+---Checks if a value exists in a given table
+---@param list table
+---@param value any
+---@return boolean
+local function list_contains(list, value)
+  for _, lv in ipairs(list) do
+    if lv == value then
+      return ture
+    end
+  end
+
+  return false
+end
 ---@param config HurlConfig
 function M.hurl(config)
   local gheight = vim.api.nvim_list_uis()[1].height
@@ -17,6 +30,7 @@ function M.hurl(config)
     style = "minimal",
     border = "rounded",
   })
+  local term = vim.api.nvim_open_term(buf,{})
 
   -- This ensures the window created is closed instead of covering the editor when a split is created
   vim.api.nvim_create_autocmd("WinLeave", {
@@ -34,35 +48,24 @@ function M.hurl(config)
   -- Build arguments list
   local hurl_args_t = vim.tbl_deep_extend("force", {}, config.hurl_flags)
   -- Always ensure the `--include` flag is passed so we can get http headers
-  if not vim.list_contains(hurl_args_t, "--include") then
+  if not list_contains(hurl_args_t, "--include") then
     table.insert(hurl_args_t, "--include")
   end
   -- If we're missing color flags then set it according to `config.color`
-  if not vim.list_contains(hurl_args_t, { "--color" }) or not vim.list_contains(hurl_args_t, { "--no-color" }) then
+  if not list_contains(hurl_args_t, { "--color" }) or not list_contains(hurl_args_t, { "--no-color" }) then
     if config.color then
       table.insert(hurl_args_t, "--color")
     else
       table.insert(hurl_args_t, "--no-color")
     end
   end
+  local hurl_args = table.concat(hurl_args_t, " ")
 
-  -- Append the hurl file to target
-  table.insert(hurl_args_t, file)
-  -- Insert the hurl command as the first element of the table. This avoids bugs where the hurl command is in the
-  -- wrong position within the table causing `vim.system` to fail
-  table.insert(hurl_args_t, 1, "hurl")
-  vim.system(
-    hurl_args_t,
-    { text = true },
-    ---@param cmd SystemCompleted
-    function(cmd)
-      vim.schedule(function()
-        local term = vim.api.nvim_open_term(buf, {})
-        vim.api.nvim_chan_send(term, table.concat(vim.split(cmd.stdout, "\n"), "\r\n"))
-        vim.api.nvim_chan_send(term, table.concat(vim.split(cmd.stderr, "\n"), "\r\n"))
-      end)
-    end
-  )
+  vim.fn.jobstart("hurl " .. file .. " " .. hurl_args, {
+    width = width,
+    on_stdout = function(chan, data) vim.api.nvim_chan_send(term,table.concat(data, "\r\n")) end,
+    on_stderr = function(chan, data) vim.api.nvim_chan_send(term,table.concat(data, "\r\n")) end
+  })
 end
 
 return M

--- a/lua/hurl/hurl.lua
+++ b/lua/hurl/hurl.lua
@@ -7,7 +7,7 @@ local M = {}
 local function list_contains(list, value)
   for _, lv in ipairs(list) do
     if lv == value then
-      return ture
+      return true
     end
   end
 

--- a/lua/hurl/hurl.lua
+++ b/lua/hurl/hurl.lua
@@ -47,10 +47,6 @@ function M.hurl(config)
 
   -- Build arguments list
   local hurl_args_t = vim.tbl_deep_extend("force", {}, config.hurl_flags)
-  -- Always ensure the `--include` flag is passed so we can get http headers
-  if not list_contains(hurl_args_t, "--include") then
-    table.insert(hurl_args_t, "--include")
-  end
   -- If we're missing color flags then set it according to `config.color`
   if not list_contains(hurl_args_t, { "--color" }) or not list_contains(hurl_args_t, { "--no-color" }) then
     if config.color then

--- a/lua/hurl/init.lua
+++ b/lua/hurl/init.lua
@@ -22,9 +22,12 @@ function M.setup(user_config)
     },
   })
   M.register_treesitter()
-  vim.api.nvim_create_user_command("Hurl", function()
-    h.hurl(config.config)
-  end, {})
+  vim.api.nvim_create_user_command("Hurl", function(cmd)
+    ---@type HurlConfig
+    local conf_copy = vim.tbl_deep_extend("force", {}, config.config)
+    conf_copy.hurl_flags = cmd.fargs
+    h.hurl(conf_copy)
+  end, { nargs = "*" })
   vim.api.nvim_create_user_command("HurlNoColor", function()
     h.hurl(vim.tbl_deep_extend("force", config.config, { color = false }))
   end, {})


### PR DESCRIPTION
This PR does two things:

1. It allows flags to be passed to (and only) the `:Hurl` command.
2. Updated the docs to reflect the changes made in the previous commits

https://github.com/pfeiferj/nvim-hurl/assets/58627896/de806784-2690-47e6-8dbc-b4b51e3216e2

Closes #9 